### PR TITLE
Pin Python3.11 package to 3.11.2-6+deb12u2 to avoid changes from CVE-2024-4032

### DIFF
--- a/python311/Dockerfile
+++ b/python311/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex \
     && apt-get clean \
     && apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y locales curl tini nano "python3.11=3.11.2-6+deb12u2" "python3.11-minimal=3.11.2-6+deb12u2" "libpython3.11-stdlib=3.11.2-6+deb12u2" "libpython3.11-minimal=3.11.2-6+deb12u2" python3.11-disutils \
+    && apt-get install -y locales curl tini nano "python3.11=3.11.2-6+deb12u2" "python3.11-minimal=3.11.2-6+deb12u2" "libpython3.11-stdlib=3.11.2-6+deb12u2" "libpython3.11-minimal=3.11.2-6+deb12u2" python3.11-distutils \
     && apt-get install -y build-essential "python3.11-dev=3.11.2-6+deb12u2" "libpython3.11-dev=3.11.2-6+deb12u2" "libpython3.11=3.11.2-6+deb12u2" \
     # Setup python /pip
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \

--- a/python311/Dockerfile
+++ b/python311/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex \
     && apt-get clean \
     && apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y locales curl tini nano "python3.11=3.11.2-6+deb12u2" "python3.11-minimal=3.11.2-6+deb12u2" "libpython3.11-stdlib=3.11.2-6+deb12u2" "libpython3.11-minimal=3.11.2-6+deb12u2" python3-disutils \
+    && apt-get install -y locales curl tini nano "python3.11=3.11.2-6+deb12u2" "python3.11-minimal=3.11.2-6+deb12u2" "libpython3.11-stdlib=3.11.2-6+deb12u2" "libpython3.11-minimal=3.11.2-6+deb12u2" python3.11-disutils \
     && apt-get install -y build-essential "python3.11-dev=3.11.2-6+deb12u2" "libpython3.11-dev=3.11.2-6+deb12u2" "libpython3.11=3.11.2-6+deb12u2" \
     # Setup python /pip
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \

--- a/python311/Dockerfile
+++ b/python311/Dockerfile
@@ -19,8 +19,8 @@ RUN set -ex \
     && apt-get clean \
     && apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y locales curl tini nano python3.11 python3.11-distutils \
-    && apt-get install -y build-essential python3.11-dev \
+    && apt-get install -y locales curl tini nano "python3.11=3.11.2-6+deb12u2" "python3.11-minimal=3.11.2-6+deb12u2" "libpython3.11-stdlib=3.11.2-6+deb12u2" "libpython3.11-minimal=3.11.2-6+deb12u2" python3-disutils \
+    && apt-get install -y build-essential "python3.11-dev=3.11.2-6+deb12u2" "libpython3.11-dev=3.11.2-6+deb12u2" "libpython3.11=3.11.2-6+deb12u2" \
     # Setup python /pip
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \


### PR DESCRIPTION
Change from https://github.com/python/cpython/commit/ba431579efdcbaed7a96f2ac4ea0775879a332fb has been backported by debian and released in `3.11.2-6+deb12u3`. There is not yet a PSF cpython 3.11 release that includes that change, so we cannot begin to adopt it. Until then we will have to hold this back for our base image.

https://tracker.debian.org/news/1559732/accepted-python311-3112-6deb12u3-source-into-stable-security/
https://release.debian.org/proposed-updates/bookworm_diffs/python3.11_3.11.2-6+deb12u3.debdiff
https://lists.debian.org/debian-security-announce/2024/msg00172.html
https://security-tracker.debian.org/tracker/CVE-2024-4032
https://github.com/python/cpython/pull/113179
