### PR TITLE
Remove pinning on python 3.11.2-6+deb12u2

### DIFF
--- a/python311/Dockerfile
+++ b/python311/Dockerfile
@@ -19,8 +19,8 @@ RUN set -ex \
     && apt-get clean \
     && apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y locales curl tini nano "python3.11=3.11.2-6+deb12u2" "python3.11-minimal=3.11.2-6+deb12u2" "libpython3.11-stdlib=3.11.2-6+deb12u2" "libpython3.11-minimal=3.11.2-6+deb12u2" python3.11-distutils \
-    && apt-get install -y build-essential "python3.11-dev=3.11.2-6+deb12u2" "libpython3.11-dev=3.11.2-6+deb12u2" "libpython3.11=3.11.2-6+deb12u2" \
+    && apt-get install -y locales curl tini nano python3.11 python3.11-distutils \
+    && apt-get install -y build-essential python3.11-dev \
     # Setup python /pip
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
@@ -44,7 +44,7 @@ RUN set -ex \
     && chown synuser:synuser /home/synuser \
     # Cleanup
     && rm -rf requirements \
-    && apt-get remove -y --purge curl build-essential python3.11-dev libpython3.11-dev libpython3.11 \
+    && apt-get remove -y --purge curl build-essential python3.11-dev \
     && apt-get remove -y --allow-remove-essential --purge e2fsprogs \
     && apt-get autoremove -y --purge \
     && apt-get clean && apt-get purge \


### PR DESCRIPTION
We are no longer affected by the ipaddress changes, since we've vendored that library from stdlib.