### PR TITLE
remove toml / tomli deps

### DIFF
--- a/requirements/requirements_dep.txt
+++ b/requirements/requirements_dep.txt
@@ -129,12 +129,6 @@ soupsieve==2.6
 # stix2-validator -> stix2-patterns
 stix2-patterns==2.0.0
 ###################################
-# pip -> toml
-toml==0.10.2
-###################################
-# pytest -> tomli
-tomli==2.0.2
-###################################
 # arrow -> types-python-dateutil
 types-python-dateutil==2.9.0.20241003
 ###################################


### PR DESCRIPTION
these predate 3.11 support which has tomllib as part of stdlib