### PR TITLE
SYN-9543: remove aioimaplib

### DIFF
--- a/requirements/requirements_synapse.txt
+++ b/requirements/requirements_synapse.txt
@@ -22,7 +22,6 @@ typing-extensions==4.14.1
 scalecodec==1.2.9
 cbor2==5.6.5
 bech32==1.2.0
-aioimaplib==1.1.0
 oauthlib==3.2.2
 pycryptodome==3.22.0
 idna==3.10


### PR DESCRIPTION
Blocked on https://github.com/vertexproject/synapse/pull/4439 being merged and released.